### PR TITLE
Fix PHP Error Forcing issues - and make it optional

### DIFF
--- a/Bundler/src/live-serve/index.php
+++ b/Bundler/src/live-serve/index.php
@@ -1,8 +1,4 @@
 <?php
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
-http_response_code(200);
-
 //Require in TWIG and the config file
 require_once (__DIR__ . "/vendor/autoload.php");
 require_once (__DIR__ . "/config.php");

--- a/Bundler/src/live-serve/index.php
+++ b/Bundler/src/live-serve/index.php
@@ -1,4 +1,5 @@
 <?php
+http_response_code(200);
 //Require in TWIG and the config file
 require_once (__DIR__ . "/vendor/autoload.php");
 require_once (__DIR__ . "/config.php");

--- a/Bundler/testing/index.php
+++ b/Bundler/testing/index.php
@@ -1,6 +1,4 @@
 <?php
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
 http_response_code(200);
 
 //Require in TWIG and the config file

--- a/Setup/basic/config.php
+++ b/Setup/basic/config.php
@@ -1,15 +1,23 @@
 <?php
-$CONFIG = Array("NAME" => "This is the name of the project");
+$CONFIG = Array(
+	"NAME" => "This is the name of the project",
+	"DEBUGGING" => false,
+);
 
 $BUNDLER_CONFIG_ARRAY = Array (
-    "files" => Array (
+	"files" => Array (
 		//Hey there maintainer. You may believe it to be a good idea in adding a "users/happy/havefun" page - it works with bundler after all! but you are wrong. Like really very wrong. You couldn't be more wrong in fact. All paths will be broken. Very broken. Such is the lovable nature of relative paths
 		//Update: This has been re-tested and confirmed to be the case
 		"index" => "main.twig",
-	    //"404" => "404.twig"
-    ),
-    "pageopts_file" => "config.php",
-    "static_file_dir" => "/static",
-    "twig_dir" => "/display",
-    "base_url" => ""
+		//"404" => "404.twig"
+	),
+	"pageopts_file" => "config.php",
+	"static_file_dir" => "/static",
+	"twig_dir" => "/display",
+	"base_url" => ""
 );
+
+if ($CONFIG['DEBUGGING']) {
+	error_reporting(E_ALL);
+	ini_set('display_errors', 1);
+}

--- a/Setup/basic/header.php
+++ b/Setup/basic/header.php
@@ -1,9 +1,4 @@
 <?php
-
-//DEV ONLY - Remeber to turn off
-error_reporting(E_ALL);
-ini_set('display_errors', 1);
-
 if (!isset($SECURE)) $SECURE = false;
 if (!isset($POST)) $POST = true;
 


### PR DESCRIPTION
Remove error forcing from the odd file (added for debugging purposes) and add the option into config (see https://github.com/BluePost/BlueUtils/pull/7/commits/a5c9f1e60dda81e496cad92e81dfb20b7237bb1b)